### PR TITLE
Final typos in the words 'conditional' and 'empirical', fix last cell example2.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Features:
 * py_banshee.sample_bn.generate_samples  --> Make samples using the defined Bayesian Network
 * py_banshee.sample_bn.sample_base_conditioning --> Make samples based conditioning on intervals
 * py_banshee.prediction.inference  --> Make predictions using a non-parametric Bayesian Network
-* py_banshee.prediction.conditinal_margins_hist  --> Visualize the un-conditional and conditional marginal histograms
+* py_banshee.prediction.conditional_margins_hist  --> Visualize the un-conditional and conditional marginal histograms
 
 #### Demo of some of the features:
 

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -8,7 +8,7 @@ from py_banshee.rankcorr import bn_rankcorr
 from py_banshee.bn_plot import bn_visualize
 from py_banshee.copula_test import cvm_statistic
 from py_banshee.d_cal import gaussian_distance
-from py_banshee.prediction import inference,conditinal_margins_hist
+from py_banshee.prediction import inference,conditional_margins_hist
 
 import numpy as np
 import pandas as pd
@@ -79,6 +79,4 @@ F = inference(condition_nodes,
               Output='full')
 #%% un-conditional and conditional marginal histograms
 #  only works if argument Output = 'full' in inference 
-conditinal_margins_hist(F,data,names,condition_nodes)
-
-
+conditional_margins_hist(F,1,data,names,condition_nodes)

--- a/examples/example_1.py
+++ b/examples/example_1.py
@@ -66,7 +66,7 @@ F = inference(Nodes = condition_nodes,      #Nodes that will be conditionalized
               parameters=parameters,        #Corresponfing parameters of the distributions
               Output='full')                #Conditional empirical distributions
 
-#%%Un-conditional and conditinal marginal histograms
+#%%Un-conditional and conditional marginal histograms
 conditional_margins_hist(F,                                 #conditional empirical distributions
                         empirical_data = 0,                 #Nodes of the NPBN are parametric distributions
                         DATA = [],                          #No empirical data is provided
@@ -75,7 +75,7 @@ conditional_margins_hist(F,                                 #conditional empiric
                         distributions=distributions,        #Corresponig distributions names of the nodes
                         parameters=parameters)              #Corresponfing parameters of the distributions
 
-# The plot shows a comprasion of un-conditional and conditinal marginal histograms.
+# The plot shows a comprasion of un-conditional and conditional marginal histograms.
 # The un-conditional marginal histograms are computed with random samples of the provided parametric distributions. 
 # The conditional marginal histograms are computed with the outpuf of the INFERENCE function.
 

--- a/py_banshee/prediction.py
+++ b/py_banshee/prediction.py
@@ -383,7 +383,7 @@ def conditional_margins_hist(F,empirical_data,DATA,names,condition_nodes,distrib
         conditional empirical distributions for each row in
         Values and each node not specified in Nodes.
     empirical_data : int
-        1 = DATA is a pd.DataFrame with emprical observations
+        1 = DATA is a pd.DataFrame with empirical observations
         if 1 distributions and parameters should be empty i.e. 
         distributions=[], parameters=[]
         0 = Nodes are parametric distributions, no empirical observations available


### PR DESCRIPTION
1. The word 'conditional' was written as 'conditinal' in two examples, as well as the ReadMe. 
2. In `example2.py`, the final line wouldn't run as it missed positional argument `empirical_data`, which should have been 1 (DATA is a pd.DataFrame with empirical observations)
3. Fixed typo in docstring `conditional_margins_hist()`